### PR TITLE
feat(reset): add possibility to reset the MCU before flashing by pull…

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -32,6 +32,7 @@ Usage: stc8prog [options]...
   -h, --help            display this message
   -p, --port <device>   set device path
   -s, --speed <baud>    set download baudrate
+  -r, --dtr reset<msec> make reset sequence by pulling low dtr
   -f, --flash <file>    flash chip with data from hex file
   -e, --erase           erase the entire chip
   -d, --debug           enable debug output

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Usage: stc8prog [options]...
   -h, --help            display this message
   -p, --port <device>   set device path
   -s, --speed <baud>    set download baudrate
+  -r, --dtr reset<msec> make reset sequence by pulling low dtr
   -f, --flash <file>    flash chip with data from hex file
   -e, --erase           erase the entire chip
   -d, --debug           enable debug output
@@ -95,6 +96,11 @@ upload_flags =
     1152000
     -e
 upload_command = ${platformio.packages_dir}/tool-stc8prog/stc8prog $UPLOAD_FLAGS -f $SOURCE
+```
+If you want to reset the MCU by pulling DTR line low, add
+    -r
+    5
+to upload_flags config
 ```
 If you want to make this env default, set it to `default_envs`
 ```

--- a/stc8prog.h
+++ b/stc8prog.h
@@ -37,24 +37,23 @@ typedef unsigned short WORD;
 #define DEBUG_PRINTF(...) if(debug){printf(__VA_ARGS__);}
 
 /* termios.c */
-
 extern int termios_open(char *path);
 extern int termios_set_speed(unsigned int speed);
 extern int termios_flush(void);
 extern int termios_setup(unsigned int speed, int databits, int stopbits, char parity);
 extern int termios_rts(bool enable);
+extern int termios_dtr(bool enable);
 extern int termios_read(void *data, unsigned long len);
 extern int termios_write(const void *data, unsigned long len);
 
 /* stc8prog.c */
-
+extern int chip_detect(uint8_t *recv);
 extern void set_debug(uint8_t val);
 extern int baudrate_set(const stc_protocol_t * stc_protocol, unsigned int speed, uint8_t *recv);
 extern int baudrate_check(const stc_protocol_t * stc_protocol, uint8_t *recv, uint8_t chip_version);
 extern int flash_erase(const stc_protocol_t * stc_protocol, uint8_t *recv);
 extern int flash_write(const stc_protocol_t * stc_protocol, unsigned int len);
 
-extern int chip_detect(uint8_t *recv);
 extern int chip_write(uint8_t *buff, uint8_t len);
 extern int chip_read(uint8_t *recv);
 extern int chip_read_verify(uint8_t *buf, uint8_t size, uint8_t *recv);

--- a/termios.c
+++ b/termios.c
@@ -171,6 +171,22 @@ int termios_rts(bool enable)
     return ioctl(ttys, TIOCMSET, &state);
 }
 
+int termios_dtr(bool enable)
+{
+    unsigned int state;
+    int ret;
+
+    if ((ret = ioctl(ttys, TIOCMGET, &state)) < 0)
+        return ret;
+
+    if (enable)
+        state |= TIOCM_DTR;
+    else
+        state &= ~TIOCM_DTR;
+
+    return ioctl(ttys, TIOCMSET, &state);
+}
+
 int termios_flush(void)
 {
     return tcflush(ttys, TCIFLUSH);


### PR DESCRIPTION
Most of usb-uart converters have dtr pin. It's can be used to reset the MCU before flashing to remove unnecessary physical operations.
To make reset by dtr flag 'r' added.