### PR TITLE
build on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ else
 		TARGET_OS += Linux
 		SRC_DIRS += ./src/serial/linux
 	endif
+	ifeq ($(UNAME_S),Darwin)
+		TARGET_OS += Darwin
+		SRC_DIRS += ./src/serial/linux
+	endif
 endif
 
 # Find all the C files we want to compile

--- a/README.md
+++ b/README.md
@@ -121,24 +121,29 @@ If there are any erros and you want to see more detailed logs, run it in the ver
 
 # Build From Source
 
-Install DEV-tools  
+#### Install DEV-tools
+* Linux
 ```shell
 sudo apt install build-essential
 ```
-Checkout the project  
+* macOS
+```shell
+xcode-select --install
+```
+
+#### Checkout the project  
 ```shell
 git clone https://github.com/IOsetting/stc8prog.git
 ```
-Compile the project
+#### Compile the project
 ```shell
 cd stc8prog
 make
 ```
-Optional: install to system path
+#### Optional: install to system path
 ```shell
 sudo make install
 ```
-
 
 # Gentoo linux
 

--- a/src/serial/linux/termios.c
+++ b/src/serial/linux/termios.c
@@ -48,6 +48,22 @@ typedef struct linux_serial {
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
+// macOS' termios.h doesn't have these baudrates defined
+#ifdef __APPLE__
+#define B460800 460800
+#define B500000 500000
+#define B576000 576000
+#define B921600 921600
+#define B1000000 1000000
+#define B1152000 1152000
+#define B1500000 1500000
+#define B2000000 2000000
+#define B2500000 2500000
+#define B3000000 3000000
+#define B3500000 3500000
+#define B4000000 4000000
+#endif
+
 static speed_t termios_speed[] = {
     B0,       B50,      B75,      B110,     B134,     B150,     B200,     
     B300,     B600,     B1200,    B1800,    B2400,    B4800,    B9600,    


### PR DESCRIPTION
The project builds perfectly with Linux `termios` serial dependency, however macOS' headers lack some of the predefined baudrates which I had to redefine in `termios.c`. 
Amended `Makefile` to make it aware of `Darwin` target OS. 
Added build instructions in `README.md`

Tested on latest macOS 12.6 and STC8G1K08A-8PIN