### PR TITLE
feat: extension of the --reset option to alternatively accept an exte…

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -29,14 +29,15 @@ STC微控制器有一个基于UART/USB的引导装入程序(BSL), 它在串口�
 
 ```
 Usage: stc8prog [options]...
-  -h, --help            display this message
-  -p, --port <device>   set device path
-  -s, --speed <baud>    set download baudrate
-  -r, --reset <msec>    make reset sequence by pulling low dtr
-  -f, --flash <file>    flash chip with data from hex file
-  -e, --erase           erase the entire chip
-  -d, --debug           enable debug output
-  -v, --version         display version information
+  -h, --help                    display this message
+  -p, --port <device>           set device path
+  -s, --speed <baud>            set download baudrate
+  -r, --reset <msec>            make reset sequence by pulling low dtr
+  -r, --reset <cmd> [args] ;    command to perform reset or power cycle
+  -f, --flash <file>            flash chip with data from hex file
+  -e, --erase                   erase the entire chip
+  -d, --debug                   enable debug output
+  -v, --version                 display version information
 
 Baudrate options: 
    4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 576000,

--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ built according to the ISP described in STC8H datasheet.
 
 ```
 Usage: stc8prog [options]...
-  -h, --help            display this message
-  -p, --port <device>   set device path
-  -s, --speed <baud>    set download baudrate
-  -r, --reset <msec>    make reset sequence by pulling low dtr
-  -f, --flash <file>    flash chip with data from hex file
-  -e, --erase           erase the entire chip
-  -d, --debug           enable debug output
-  -v, --version         display version information
+  -h, --help                    display this message
+  -p, --port <device>           set device path
+  -s, --speed <baud>            set download baudrate
+  -r, --reset <msec>            make reset sequence by pulling low dtr
+  -r, --reset <cmd> [args] ;    command to perform reset or power cycle
+  -f, --flash <file>            flash chip with data from hex file
+  -e, --erase                   erase the entire chip
+  -d, --debug                   enable debug output
+  -v, --version                 display version information
 
 Baudrate options: 
    4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 576000,

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,9 @@
 #define CHIP_DETECT_RST_TRYCOUNT    (uint16_t)(0x20)
 #define CHIP_DETECT_WAIT_TRYCOUNT   (uint16_t)(0x7FF)
 
+/* length of the array containing the args of the reset cmd */
+#define LEN_RESET_ARGS 32
+
 static const struct option options[] = {
     {"help",        no_argument,        0,  'h'},
     {"port",        required_argument,  0,  'p'},
@@ -146,7 +149,7 @@ int main(int argc, char *const argv[])
     unsigned int speed = DEFAULTS_SPEED;
     uint32_t reset_time = 0;
     char *reset_cmd = NULL;
-    char *reset_args[32];
+    char *reset_args[LEN_RESET_ARGS];
     char *file = NULL;
     char *port = DEFAULTS_PORT;
     int ret, hex_size;
@@ -179,9 +182,13 @@ int main(int argc, char *const argv[])
                 } else {
                     int idx = 0;
                     reset_cmd = reset_args[idx++] = optarg;
-                    while (optind < argc && idx < sizeof(reset_args) / sizeof(char*)) {
+                    while (optind < argc && idx < LEN_RESET_ARGS) {
                        if (strcmp(argv[optind], ";") == 0) break;
                        reset_args[idx++] = argv[optind++];
+                    }
+                    if (idx == LEN_RESET_ARGS) {
+                       puts("Reset command has too many arguments.");
+                       exit(1);
                     }
                     reset_args[idx] = NULL;
                 }


### PR DESCRIPTION
…rnal command to reset or power cycle the MCU

The --reset option alternatively accepts an external command, which resets or power cycles the MCU, e.g.:

```
stc8prog -p /dev/ttyUSB0 -r tools/koradctl /dev/ttyACM3 off-on \; -e -f obj/ledtest.ihx
Loading hex file:    Loaded 363 bytes between: 0000 to 0171
Opening port /dev/ttyUSB0: done
Running reset command and waiting for MCU: detected
MCU type: STC8G1K08A-8PIN
Protocol: STC8G/8H
F/W version: 7.3.12U
IRC frequency(Hz): unadjusted
Switching to 115200 baud, chip: set, host: set, ping: succ
Erasing chip: succ
Writing flash, size 370: 100.00% done
```

The command must be terminated with a semicolon.

For the above example I used a STC8G1K08A 8pin MCU on a breadboard powered by a Korad KD3005P lab power supply. The command "koradctl" is a very simple Python program:

```
#!/usr/bin/python3
# Very simple control script for Korad KD3005P Lab Power Supply

import argparse
import serial
import time

commands = ('ident', 'on', 'off', 'off-on')

parser = argparse.ArgumentParser()
parser.add_argument("port", help="serial device, e.g. /dev/ttyACM0")
parser.add_argument("command", choices=commands, help="command to execute")
args = parser.parse_args()

with serial.Serial(args.port, timeout=1) as port:
    if args.command == 'ident':
        port.write(b'*IDN?')
        print(port.read(30).decode('ascii'))
    elif args.command == 'on':
        port.write(b'OUT1')
    elif args.command == 'off':
        port.write(b'OUT0')
    elif args.command == 'off-on':
        port.write(b'OUT0')
        time.sleep(1)
        port.write(b'OUT1')

```
The new feature has only been tested on Linux.